### PR TITLE
Revert "Fix endpoint configuration for settings"

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -108,10 +108,13 @@ Route::prefix('v1')->group(function () {
             // Settings (read-only for observers)
             Route::get('/settings', [SettingsController::class, 'index']);
             Route::get('/settings/shift-config', [SettingsController::class, 'getShiftConfig']);
+            Route::get('/settings/bot-config', [SettingsController::class, 'getBotConfig']);
             Route::get('/settings/{key}', [SettingsController::class, 'show']);
 
             // Only managers and owners can modify settings
-            Route::put('/settings/shift-config', [SettingsController::class, 'updateShiftConfig'])
+            Route::post('/settings/shift-config', [SettingsController::class, 'updateShiftConfig'])
+                ->middleware('role:manager,owner');
+            Route::post('/settings/bot-config', [SettingsController::class, 'updateBotConfig'])
                 ->middleware('role:manager,owner');
             Route::post('/settings', [SettingsController::class, 'store'])
                 ->middleware('role:manager,owner');

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -3099,7 +3099,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-    put:
+    post:
       tags:
         - Settings
       summary: Обновить конфигурацию смен
@@ -3167,6 +3167,180 @@ paths:
                     additionalProperties:
                       oneOf:
                         - type: string
+                        - type: integer
+        '401':
+          description: Неавторизован
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '422':
+          description: Ошибка валидации
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  errors:
+                    type: object
+
+  /settings/bot-config:
+    get:
+      tags:
+        - Settings
+      summary: Получить конфигурацию бота
+      description: Получение настроек Telegram бота и смен
+      operationId: getBotConfig
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: dealership_id
+          in: query
+          description: ID автосалона (если не указан, возвращается глобальная конфигурация)
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '200':
+          description: Конфигурация бота
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      telegram_bot_id:
+                        type: string
+                        nullable: true
+                        example: "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+                      telegram_bot_username:
+                        type: string
+                        nullable: true
+                        example: "taskmate_bot"
+                      telegram_webhook_url:
+                        type: string
+                        format: uri
+                        nullable: true
+                        example: "https://example.com/api/webhook"
+                      notification_enabled:
+                        type: boolean
+                        example: true
+                      shift_1_start_time:
+                        type: string
+                        format: time
+                        example: "09:00"
+                        description: Время начала первой смены
+                      shift_1_end_time:
+                        type: string
+                        format: time
+                        example: "18:00"
+                        description: Время окончания первой смены
+                      shift_2_start_time:
+                        type: string
+                        format: time
+                        example: "18:00"
+                        description: Время начала второй смены
+                      shift_2_end_time:
+                        type: string
+                        format: time
+                        example: "02:00"
+                        description: Время окончания второй смены
+                      late_tolerance_minutes:
+                        type: integer
+                        example: 15
+                        description: Допустимое время опоздания в минутах
+        '401':
+          description: Неавторизован
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      tags:
+        - Settings
+      summary: Обновить конфигурацию бота
+      description: Обновление настроек Telegram бота и смен
+      operationId: updateBotConfig
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                telegram_bot_id:
+                  type: string
+                  nullable: true
+                  description: Telegram Bot ID
+                  example: "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+                telegram_bot_username:
+                  type: string
+                  nullable: true
+                  description: Telegram Bot Username
+                  example: "taskmate_bot"
+                telegram_webhook_url:
+                  type: string
+                  format: uri
+                  nullable: true
+                  description: Telegram Webhook URL
+                  example: "https://example.com/api/webhook"
+                notification_enabled:
+                  type: boolean
+                  nullable: true
+                  description: Включить/выключить уведомления
+                  example: true
+                shift_start_time:
+                  type: string
+                  format: time
+                  nullable: true
+                  description: Время начала смены (формат HH:MM)
+                  example: "09:00"
+                shift_end_time:
+                  type: string
+                  format: time
+                  nullable: true
+                  description: Время окончания смены (формат HH:MM)
+                  example: "18:00"
+                late_tolerance_minutes:
+                  type: integer
+                  nullable: true
+                  description: Допустимое время опоздания в минутах
+                  example: 15
+                dealership_id:
+                  type: integer
+                  nullable: true
+                  example: 1
+      responses:
+        '200':
+          description: Конфигурация бота успешно обновлена
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: Bot configuration updated successfully
+                  data:
+                    type: object
+                    additionalProperties:
+                      oneOf:
+                        - type: string
+                        - type: boolean
                         - type: integer
         '401':
           description: Неавторизован


### PR DESCRIPTION
Reverts xierongchuan/TaskMateTelegramBot#25

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the previous settings endpoint change and restores the intended API: POST for shift-config and new bot-config endpoints, with Swagger updated. This brings back bot config read/write and aligns routes, validation, and role guards.

- **New Features**
  - Added GET /api/v1/settings/bot-config to fetch bot and shift settings.
  - Added POST /api/v1/settings/bot-config to update bot and optional shift fields.
  - Switched /api/v1/settings/shift-config to POST; kept manager/owner role guard.
  - Updated swagger.yaml to document the above endpoints and request/response shapes.

<!-- End of auto-generated description by cubic. -->

