### PR TITLE
Scope ImportantLink access by dealership

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,35 +1,35 @@
-name: TaskMate Server CI/CD
-
-on:
-  # push:
-  #   branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
-jobs:
-  laravel-tests:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
-      with:
-        php-version: '8.4'
-    - uses: actions/checkout@v4
-    - name: Copy .env
-      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
-    - name: Install Dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-    - name: Generate key
-      run: php artisan key:generate
-    - name: Directory Permissions
-      run: chmod -R 777 storage bootstrap/cache
-    - name: Create Database
-      run: |
-        mkdir -p database
-        touch database/database.sqlite
-    - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
-      env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
-      run: php artisan test
+# # name: TaskMate Server CI/CD
+# #
+# # on:
+# #   # push:
+# #   #   branches: [ "main" ]
+# #   pull_request:
+# #     branches: [ "main" ]
+# #
+# # jobs:
+# #   laravel-tests:
+# #
+# #     runs-on: ubuntu-latest
+# #
+# #     steps:
+# #     - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+# #       with:
+# #         php-version: '8.4'
+# #     - uses: actions/checkout@v4
+# #     - name: Copy .env
+# #       run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+# #     - name: Install Dependencies
+# #       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+# #     - name: Generate key
+# #       run: php artisan key:generate
+# #     - name: Directory Permissions
+# #       run: chmod -R 777 storage bootstrap/cache
+# #     - name: Create Database
+# #       run: |
+# #         mkdir -p database
+# #         touch database/database.sqlite
+# #     - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
+# #       env:
+# #         DB_CONNECTION: sqlite
+# #         DB_DATABASE: database/database.sqlite
+# #       run: php artisan test

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T14:15:26.329Z for PR creation at branch issue-34-c2f39fa62539 for issue https://github.com/xierongchuan/TaskMateServer/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T14:15:26.329Z for PR creation at branch issue-34-c2f39fa62539 for issue https://github.com/xierongchuan/TaskMateServer/issues/34

--- a/app/Http/Controllers/Api/V1/ImportantLinkController.php
+++ b/app/Http/Controllers/Api/V1/ImportantLinkController.php
@@ -95,16 +95,7 @@ class ImportantLinkController extends Controller
 
         $this->authorize('create', ImportantLink::class);
 
-        $dealershipId = $this->normalizeDealershipId($validated['dealership_id'] ?? null);
-
-        if ($dealershipId === null && ! $this->isOwner($currentUser)) {
-            return response()->json([
-                'message' => 'The dealership id field is required.',
-                'errors' => [
-                    'dealership_id' => ['The dealership id field is required.'],
-                ],
-            ], 422);
-        }
+        $dealershipId = $this->normalizeDealershipId($validated['dealership_id']);
 
         if ($accessError = $this->validateDealershipAccess($currentUser, $dealershipId)) {
             return $accessError;

--- a/app/Http/Controllers/Api/V1/ImportantLinkController.php
+++ b/app/Http/Controllers/Api/V1/ImportantLinkController.php
@@ -95,10 +95,9 @@ class ImportantLinkController extends Controller
 
         $this->authorize('create', ImportantLink::class);
 
-        if (
-            (! array_key_exists('dealership_id', $validated) || $validated['dealership_id'] === null)
-            && ! $this->isOwner($currentUser)
-        ) {
+        $dealershipId = $this->normalizeDealershipId($validated['dealership_id'] ?? null);
+
+        if ($dealershipId === null && ! $this->isOwner($currentUser)) {
             return response()->json([
                 'message' => 'The dealership id field is required.',
                 'errors' => [
@@ -106,8 +105,6 @@ class ImportantLinkController extends Controller
                 ],
             ], 422);
         }
-
-        $dealershipId = $this->normalizeDealershipId($validated['dealership_id'] ?? null);
 
         if ($accessError = $this->validateDealershipAccess($currentUser, $dealershipId)) {
             return $accessError;
@@ -138,21 +135,17 @@ class ImportantLinkController extends Controller
         $validated = $request->validated();
 
         // Проверка доступа к новому дилерству, если меняется
-        if (
-            array_key_exists('dealership_id', $validated)
-            && ! $this->isOwner($currentUser)
-            && $validated['dealership_id'] === null
-        ) {
-            return response()->json([
-                'message' => 'The dealership id field is required.',
-                'errors' => [
-                    'dealership_id' => ['The dealership id field is required.'],
-                ],
-            ], 422);
-        }
-
         if (array_key_exists('dealership_id', $validated)) {
             $validated['dealership_id'] = $this->normalizeDealershipId($validated['dealership_id']);
+
+            if ($validated['dealership_id'] === null && ! $this->isOwner($currentUser)) {
+                return response()->json([
+                    'message' => 'The dealership id field is required.',
+                    'errors' => [
+                        'dealership_id' => ['The dealership id field is required.'],
+                    ],
+                ], 422);
+            }
         }
 
         if (array_key_exists('dealership_id', $validated) && $validated['dealership_id'] !== $link->dealership_id) {

--- a/app/Http/Controllers/Api/V1/ImportantLinkController.php
+++ b/app/Http/Controllers/Api/V1/ImportantLinkController.php
@@ -95,7 +95,10 @@ class ImportantLinkController extends Controller
 
         $this->authorize('create', ImportantLink::class);
 
-        if (! array_key_exists('dealership_id', $validated) && ! $this->isOwner($currentUser)) {
+        if (
+            (! array_key_exists('dealership_id', $validated) || $validated['dealership_id'] === null)
+            && ! $this->isOwner($currentUser)
+        ) {
             return response()->json([
                 'message' => 'The dealership id field is required.',
                 'errors' => [
@@ -104,9 +107,13 @@ class ImportantLinkController extends Controller
             ], 422);
         }
 
-        if ($accessError = $this->validateDealershipAccess($currentUser, $validated['dealership_id'] ?? null)) {
+        $dealershipId = $this->normalizeDealershipId($validated['dealership_id'] ?? null);
+
+        if ($accessError = $this->validateDealershipAccess($currentUser, $dealershipId)) {
             return $accessError;
         }
+
+        $validated['dealership_id'] = $dealershipId;
 
         // Устанавливаем creator_id из текущего пользователя
         $validated['creator_id'] = $currentUser->id;
@@ -144,6 +151,10 @@ class ImportantLinkController extends Controller
             ], 422);
         }
 
+        if (array_key_exists('dealership_id', $validated)) {
+            $validated['dealership_id'] = $this->normalizeDealershipId($validated['dealership_id']);
+        }
+
         if (array_key_exists('dealership_id', $validated) && $validated['dealership_id'] !== $link->dealership_id) {
             if ($accessError = $this->validateDealershipAccess($currentUser, $validated['dealership_id'])) {
                 return $accessError;
@@ -177,5 +188,10 @@ class ImportantLinkController extends Controller
 
             return $this->serverErrorResponse('Ошибка при удалении ссылки', $e);
         }
+    }
+
+    private function normalizeDealershipId(mixed $dealershipId): ?int
+    {
+        return $dealershipId === null ? null : (int) $dealershipId;
     }
 }

--- a/app/Http/Controllers/Api/V1/ImportantLinkController.php
+++ b/app/Http/Controllers/Api/V1/ImportantLinkController.php
@@ -29,14 +29,13 @@ class ImportantLinkController extends Controller
 
         $query = ImportantLink::with(['creator', 'dealership']);
 
-        // Проверка доступа к конкретному дилерству, если указан
         if ($dealershipId !== null) {
             if ($accessError = $this->validateDealershipAccess($currentUser, $dealershipId)) {
                 return $accessError;
             }
+
             $query->where('dealership_id', $dealershipId);
         } else {
-            // Ограничиваем выборку доступными дилерствами
             $this->scopeByAccessibleDealerships($query, $currentUser);
         }
 
@@ -96,11 +95,17 @@ class ImportantLinkController extends Controller
 
         $this->authorize('create', ImportantLink::class);
 
-        // Проверка доступа к дилерству, если указан
-        if (! empty($validated['dealership_id'])) {
-            if ($accessError = $this->validateDealershipAccess($currentUser, (int) $validated['dealership_id'])) {
-                return $accessError;
-            }
+        if (! array_key_exists('dealership_id', $validated) && ! $this->isOwner($currentUser)) {
+            return response()->json([
+                'message' => 'The dealership id field is required.',
+                'errors' => [
+                    'dealership_id' => ['The dealership id field is required.'],
+                ],
+            ], 422);
+        }
+
+        if ($accessError = $this->validateDealershipAccess($currentUser, $validated['dealership_id'] ?? null)) {
+            return $accessError;
         }
 
         // Устанавливаем creator_id из текущего пользователя
@@ -126,8 +131,21 @@ class ImportantLinkController extends Controller
         $validated = $request->validated();
 
         // Проверка доступа к новому дилерству, если меняется
-        if (isset($validated['dealership_id']) && $validated['dealership_id'] !== $link->dealership_id) {
-            if ($accessError = $this->validateDealershipAccess($currentUser, (int) $validated['dealership_id'])) {
+        if (
+            array_key_exists('dealership_id', $validated)
+            && ! $this->isOwner($currentUser)
+            && $validated['dealership_id'] === null
+        ) {
+            return response()->json([
+                'message' => 'The dealership id field is required.',
+                'errors' => [
+                    'dealership_id' => ['The dealership id field is required.'],
+                ],
+            ], 422);
+        }
+
+        if (array_key_exists('dealership_id', $validated) && $validated['dealership_id'] !== $link->dealership_id) {
+            if ($accessError = $this->validateDealershipAccess($currentUser, $validated['dealership_id'])) {
                 return $accessError;
             }
         }

--- a/app/Http/Requests/Api/V1/StoreImportantLinkRequest.php
+++ b/app/Http/Requests/Api/V1/StoreImportantLinkRequest.php
@@ -26,7 +26,7 @@ class StoreImportantLinkRequest extends FormRequest
             'url' => 'required|string|max:1000|url',
             'description' => 'nullable|string',
             'category' => 'nullable|string|max:50',
-            'dealership_id' => 'nullable|integer|exists:auto_dealerships,id',
+            'dealership_id' => 'required|integer|exists:auto_dealerships,id',
             'sort_order' => 'integer',
             'is_active' => 'boolean',
         ];

--- a/app/Policies/ImportantLinkPolicy.php
+++ b/app/Policies/ImportantLinkPolicy.php
@@ -21,11 +21,11 @@ class ImportantLinkPolicy
      */
     public function view(User $user, ImportantLink $link): Response
     {
-        if ($link->dealership_id === null || $this->dealershipAccess->isOwner($user)) {
+        if ($this->dealershipAccess->isOwner($user)) {
             return Response::allow();
         }
 
-        if ($this->dealershipAccess->hasAccessToDealership($user, $link->dealership_id)) {
+        if ($link->dealership_id !== null && $this->dealershipAccess->hasAccessToDealership($user, $link->dealership_id)) {
             return Response::allow();
         }
 

--- a/tests/Feature/Api/ImportantLinkTest.php
+++ b/tests/Feature/Api/ImportantLinkTest.php
@@ -349,6 +349,18 @@ describe('Important Links API Endpoints', function () {
                 ->assertJsonValidationErrors(['dealership_id']);
         });
 
+        it('forbids managers from creating links with empty dealership_id', function () {
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->postJson('/api/v1/links', [
+                    'title' => 'Empty Dealership Resource',
+                    'url' => 'https://empty-dealership.example.com',
+                    'dealership_id' => '',
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
+        });
+
         it('accepts validated string dealership IDs when creating links', function () {
             $response = $this->actingAs($this->manager, 'sanctum')
                 ->postJson('/api/v1/links', [
@@ -571,6 +583,21 @@ describe('Important Links API Endpoints', function () {
             $response = $this->actingAs($this->manager, 'sanctum')
                 ->putJson('/api/v1/links/'.$link->id, [
                     'dealership_id' => null,
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
+        });
+
+        it('forbids managers from clearing dealership_id with an empty string', function () {
+            $link = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+            ]);
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->putJson('/api/v1/links/'.$link->id, [
+                    'dealership_id' => '',
                 ]);
 
             $response->assertStatus(422)

--- a/tests/Feature/Api/ImportantLinkTest.php
+++ b/tests/Feature/Api/ImportantLinkTest.php
@@ -376,7 +376,7 @@ describe('Important Links API Endpoints', function () {
             expect($link->dealership_id)->toBe($this->dealership->id);
         });
 
-        it('allows owner to create global link when dealership_id is null', function () {
+        it('requires owners to attach created links to a dealership', function () {
             $owner = User::factory()->create(['role' => Role::OWNER->value]);
 
             $linkData = [
@@ -388,11 +388,8 @@ describe('Important Links API Endpoints', function () {
             $response = $this->actingAs($owner, 'sanctum')
                 ->postJson('/api/v1/links', $linkData);
 
-            $response->assertStatus(201)
-                ->assertJson(['success' => true, 'data' => ['title' => 'Global Resource']]);
-
-            $link = ImportantLink::where('title', 'Global Resource')->first();
-            expect($link->dealership_id)->toBeNull();
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
         });
 
         it('forbids managers from creating links for inaccessible dealerships', function () {

--- a/tests/Feature/Api/ImportantLinkTest.php
+++ b/tests/Feature/Api/ImportantLinkTest.php
@@ -337,6 +337,33 @@ describe('Important Links API Endpoints', function () {
                 ->assertJsonValidationErrors(['dealership_id']);
         });
 
+        it('forbids managers from creating links with explicit null dealership_id', function () {
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->postJson('/api/v1/links', [
+                    'title' => 'Global Resource',
+                    'url' => 'https://global.example.com',
+                    'dealership_id' => null,
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
+        });
+
+        it('accepts validated string dealership IDs when creating links', function () {
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->postJson('/api/v1/links', [
+                    'title' => 'String Dealership Link',
+                    'url' => 'https://string-id.example.com',
+                    'dealership_id' => (string) $this->dealership->id,
+                ]);
+
+            $response->assertStatus(201)
+                ->assertJson(['success' => true, 'data' => ['title' => 'String Dealership Link']]);
+
+            $link = ImportantLink::where('title', 'String Dealership Link')->first();
+            expect($link->dealership_id)->toBe($this->dealership->id);
+        });
+
         it('allows owner to create global link when dealership_id is null', function () {
             $owner = User::factory()->create(['role' => Role::OWNER->value]);
 
@@ -548,6 +575,25 @@ describe('Important Links API Endpoints', function () {
 
             $response->assertStatus(422)
                 ->assertJsonValidationErrors(['dealership_id']);
+        });
+
+        it('accepts validated string dealership IDs when updating links', function () {
+            $attachedDealership = AutoDealership::factory()->create();
+            $this->manager->dealerships()->attach($attachedDealership->id);
+            $link = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+            ]);
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->putJson('/api/v1/links/'.$link->id, [
+                    'dealership_id' => (string) $attachedDealership->id,
+                ]);
+
+            $response->assertStatus(200);
+
+            $link->refresh();
+            expect($link->dealership_id)->toBe($attachedDealership->id);
         });
 
         it('requires manager or owner role', function () {

--- a/tests/Feature/Api/ImportantLinkTest.php
+++ b/tests/Feature/Api/ImportantLinkTest.php
@@ -72,6 +72,69 @@ describe('Important Links API Endpoints', function () {
             expect($response->json('data'))->toHaveCount(3);
         });
 
+        it('only returns links for dealerships accessible to the user', function () {
+            $otherDealership = AutoDealership::factory()->create();
+            $attachedDealership = AutoDealership::factory()->create();
+            $this->manager->dealerships()->attach($attachedDealership->id);
+
+            $primaryLink = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+                'title' => 'Primary Dealership Link',
+            ]);
+            $attachedLink = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $attachedDealership->id,
+                'title' => 'Attached Dealership Link',
+            ]);
+            ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $otherDealership->id,
+                'title' => 'Other Dealership Link',
+            ]);
+            ImportantLink::factory()->global()->create([
+                'creator_id' => $this->manager->id,
+                'title' => 'Global Link',
+            ]);
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->getJson('/api/v1/links');
+
+            $response->assertStatus(200);
+
+            $ids = collect($response->json('data'))->pluck('id')->all();
+            expect($ids)->toContain($primaryLink->id)
+                ->and($ids)->toContain($attachedLink->id)
+                ->and($ids)->toHaveCount(2);
+        });
+
+        it('allows owner to see links from every dealership and global links', function () {
+            $owner = User::factory()->create(['role' => Role::OWNER->value]);
+            $otherDealership = AutoDealership::factory()->create();
+
+            $dealershipLink = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+            ]);
+            $otherDealershipLink = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $otherDealership->id,
+            ]);
+            $globalLink = ImportantLink::factory()->global()->create([
+                'creator_id' => $owner->id,
+            ]);
+
+            $response = $this->actingAs($owner, 'sanctum')
+                ->getJson('/api/v1/links');
+
+            $response->assertStatus(200);
+
+            $ids = collect($response->json('data'))->pluck('id')->all();
+            expect($ids)->toContain($dealershipLink->id)
+                ->and($ids)->toContain($otherDealershipLink->id)
+                ->and($ids)->toContain($globalLink->id);
+        });
+
         it('filters links by is_active status', function () {
             // Arrange
             ImportantLink::factory()->count(3)->create([
@@ -100,6 +163,18 @@ describe('Important Links API Endpoints', function () {
 
             // Assert
             $response->assertStatus(401);
+        });
+
+        it('forbids direct access to a link from another dealership', function () {
+            $otherDealership = AutoDealership::factory()->create();
+            $link = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $otherDealership->id,
+            ]);
+
+            $this->actingAs($this->manager, 'sanctum')
+                ->getJson('/api/v1/links/'.$link->id)
+                ->assertStatus(403);
         });
 
         it('searches links by title, url, and description', function () {
@@ -245,7 +320,7 @@ describe('Important Links API Endpoints', function () {
                 ->and($link->creator_id)->toBe($this->manager->id);
         });
 
-        it('creates global link when dealership_id is null', function () {
+        it('requires managers to attach created links to an accessible dealership', function () {
             // Arrange
             $linkData = [
                 'title' => 'Global Resource',
@@ -258,11 +333,44 @@ describe('Important Links API Endpoints', function () {
                 ->postJson('/api/v1/links', $linkData);
 
             // Assert
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
+        });
+
+        it('allows owner to create global link when dealership_id is null', function () {
+            $owner = User::factory()->create(['role' => Role::OWNER->value]);
+
+            $linkData = [
+                'title' => 'Global Resource',
+                'url' => 'https://global.example.com',
+                'sort_order' => 0,
+            ];
+
+            $response = $this->actingAs($owner, 'sanctum')
+                ->postJson('/api/v1/links', $linkData);
+
             $response->assertStatus(201)
                 ->assertJson(['success' => true, 'data' => ['title' => 'Global Resource']]);
 
             $link = ImportantLink::where('title', 'Global Resource')->first();
             expect($link->dealership_id)->toBeNull();
+        });
+
+        it('forbids managers from creating links for inaccessible dealerships', function () {
+            $otherDealership = AutoDealership::factory()->create();
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->postJson('/api/v1/links', [
+                    'title' => 'Other Dealership Link',
+                    'url' => 'https://other.example.com',
+                    'dealership_id' => $otherDealership->id,
+                ]);
+
+            $response->assertStatus(403)
+                ->assertJson([
+                    'success' => false,
+                    'message' => 'Нет доступа к указанному дилерству',
+                ]);
         });
 
         it('validates required fields', function () {
@@ -406,6 +514,40 @@ describe('Important Links API Endpoints', function () {
             // Assert
             $response->assertStatus(422)
                 ->assertJsonValidationErrors(['url']);
+        });
+
+        it('forbids managers from moving links to inaccessible dealerships', function () {
+            $otherDealership = AutoDealership::factory()->create();
+            $link = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+            ]);
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->putJson('/api/v1/links/'.$link->id, [
+                    'dealership_id' => $otherDealership->id,
+                ]);
+
+            $response->assertStatus(403)
+                ->assertJson([
+                    'success' => false,
+                    'message' => 'Нет доступа к указанному дилерству',
+                ]);
+        });
+
+        it('forbids managers from making links global', function () {
+            $link = ImportantLink::factory()->create([
+                'creator_id' => $this->manager->id,
+                'dealership_id' => $this->dealership->id,
+            ]);
+
+            $response = $this->actingAs($this->manager, 'sanctum')
+                ->putJson('/api/v1/links/'.$link->id, [
+                    'dealership_id' => null,
+                ]);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['dealership_id']);
         });
 
         it('requires manager or owner role', function () {

--- a/tests/Feature/Api/ImportantLinkTest.php
+++ b/tests/Feature/Api/ImportantLinkTest.php
@@ -471,7 +471,7 @@ describe('Important Links API Endpoints', function () {
             $this->actingAs($this->employee, 'sanctum')
                 ->postJson('/api/v1/links', $linkData)
                 ->assertStatus(403);
-                
+
             // Act & Assert - Try as observer
             $this->actingAs($this->observer, 'sanctum')
                 ->postJson('/api/v1/links', $linkData)


### PR DESCRIPTION
Fixes xierongchuan/TaskMateServer#34

## Summary
- restrict ImportantLink list/show access to the authenticated user's accessible dealerships
- keep owner users able to view all ImportantLinks, including legacy/global links
- require every new ImportantLink to include a valid `dealership_id`, including owner-created links
- require non-owner managers to create and update ImportantLinks with an accessible `dealership_id`
- reject omitted, null, and empty-string `dealership_id` values from create flows so new global links cannot be created
- normalize validated non-null `dealership_id` values to integers before strict access checks
- add regression coverage for dealership scoping, owner visibility, inaccessible dealerships, required create dealership binding, explicit-null and empty-string rejection, and string ID create/update payloads
- clean up touched test formatting for Pint compatibility
- comment out `.github/workflows/cicd.yml` per maintainer request because that workflow is not needed

## Reproduction
Before this change, ImportantLink dealership scoping was incomplete: managers could see or directly access links outside their dealerships, and write flows could create or preserve global links instead of requiring an accessible dealership. Cubic also identified that null-like create payloads and validated string IDs needed explicit handling before the strict `?int` access helper path. A later maintainer comment clarified that creating an ImportantLink without a Dealership must be impossible, so `dealership_id` is now required for all create requests.

## Tests
- `php -l app/Http/Controllers/Api/V1/ImportantLinkController.php`
- `php -l app/Policies/ImportantLinkPolicy.php`
- `php -l app/Http/Requests/Api/V1/StoreImportantLinkRequest.php`
- `php -l app/Http/Requests/Api/V1/UpdateImportantLinkRequest.php`
- `php -l tests/Feature/Api/ImportantLinkTest.php`
- `git diff --check upstream/main...HEAD`

Full Laravel/Pest tests were not run locally because this container does not have Composer installed, has no `vendor/autoload.php`, and has PHP 8.3 while the project requires PHP 8.4.

## CI note
The previous `laravel-tests` workflow could not start because GitHub Actions reported account/billing infrastructure errors. Per maintainer feedback, `.github/workflows/cicd.yml` is now kept in place but fully commented out because it is not needed.
